### PR TITLE
Manual: automated link checking using mdbook-linkcheck

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ env:
 
 before_script:
   - rustup component add rustfmt
+  - if [[ -n "$BUILD_DOCS" ]]; then (cargo install mdbook --force || true); fi
+  - if [[ -n "$BUILD_DOCS" ]]; then (cargo install mdbook-linkcheck --force || true); fi
 
 matrix:
   fast_finish: true

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -4,3 +4,13 @@ language = "en"
 multilingual = false
 src = "src"
 title = "Async programming in Rust with async-std"
+
+
+[output.linkcheck]
+# Should we check links on the internet? Enabling this option adds a
+# non-negligible performance impact
+follow-web-links = false
+
+# Are we allowed to link to files outside of the book's root directory? This
+# may help prevent linking to sensitive files (e.g. "../../../../etc/shadow")
+traverse-parent-directories = false


### PR DESCRIPTION
MDBook LinkCheck is a backend for mdbook which check both internal and
external links (https://github.com/Michael-F-Bryan/mdbook-linkcheck).
    
This PR leaves external links unchecked for performance reasons ;
they can be checked by setting `follow-web-links = true` in the
book.toml config file.